### PR TITLE
[CROSS-TEAM]Change static uid/gid to dynamic uid/gid

### DIFF
--- a/auth/flagupdater.py
+++ b/auth/flagupdater.py
@@ -32,8 +32,8 @@ def initialize_gpg():
             assert result
 
     # chown 'vagrant:vagrant'
-    uid = pwd.getpwnam("vagrant").pw_uid
-    gid = grp.getgrnam("vagrant").gr_gid
+    uid = os.getuid()
+    gid = os.getgid()
     os.chown(homedir+"/pubring.gpg", uid, gid)
     os.chown(homedir+"/pubring.gpg~", uid, gid)
 


### PR DESCRIPTION
Change static uid/gid to dynamic uid/gid

Vagrant의 uid/gid를 받아 사용해서 default가 root인 도커에서 문제가 발생
동적으로 프로그램 실행 권한의  uid/gid 받는 것으로 변경 (docker에서는 기본 root)